### PR TITLE
Sort issues by

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Every argument is optional.
 | [ignore-issue-updates](#ignore-issue-updates)                       | Override [ignore-updates](#ignore-updates) for issues only                  |                       |
 | [ignore-pr-updates](#ignore-pr-updates)                             | Override [ignore-updates](#ignore-updates) for PRs only                     |                       |
 | [include-only-assigned](#include-only-assigned)                     | Process only assigned issues                                                | `false`               |
-| [sort-issues-by](#sort-issues-by)                                   | What to sort issues by                                                      | `created`             |
+| [sort-issues-by](#sort-issues-by)                                   | What to sort issues and PRs by                                                      | `created`             |
 
 ### List of output options
 

--- a/README.md
+++ b/README.md
@@ -551,7 +551,7 @@ Default value: `false`
 
 #### sort-issues-by
 
-Useful to sort the issues by the specified field. It accepts 'created', 'updated', 'comments'.
+Useful to sort the issues by the specified field. It accepts `created`, `updated`, `comments`.
 
 Default value: `created`
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Every argument is optional.
 | [ignore-issue-updates](#ignore-issue-updates)                       | Override [ignore-updates](#ignore-updates) for issues only                  |                       |
 | [ignore-pr-updates](#ignore-pr-updates)                             | Override [ignore-updates](#ignore-updates) for PRs only                     |                       |
 | [include-only-assigned](#include-only-assigned)                     | Process only assigned issues                                                | `false`               |
+| [sort-issues-by](#sort-issues-by)                                   | What to sort issues by                                                      | `created`             |
 
 ### List of output options
 
@@ -547,6 +548,13 @@ Default value: unset
 If set to `true`, only the issues or the pull requests with an assignee will be marked as stale automatically.
 
 Default value: `false`
+
+#### sort-issues-by
+
+Useful to sort the issues by the specified field. It accepts 'created', 'updated', 'comments'.
+
+Default value: `created`
+
 
 ### Usage
 

--- a/README.md
+++ b/README.md
@@ -551,7 +551,7 @@ Default value: `false`
 
 #### sort-issues-by
 
-Useful to sort the issues by the specified field. It accepts `created`, `updated`, `comments`.
+Useful to sort the issues and PRs by the specified field. It accepts `created`, `updated`, `comments`.
 
 Default value: `created`
 

--- a/__tests__/constants/default-processor-options.ts
+++ b/__tests__/constants/default-processor-options.ts
@@ -32,6 +32,7 @@ export const DefaultProcessorOptions: IIssuesProcessorOptions = Object.freeze({
   removeIssueStaleWhenUpdated: undefined,
   removePrStaleWhenUpdated: undefined,
   ascending: false,
+  sortIssuesBy: 'created',
   deleteBranch: false,
   startDate: '',
   exemptMilestones: '',

--- a/action.yml
+++ b/action.yml
@@ -137,7 +137,7 @@ inputs:
     default: 'false'
     required: false
   sort-issues-by:
-    description: 'What to sort results by'
+    description: 'What to sort results by. Valid options are `created`, `updated`, and `comments`. Defaults to `created`.'
     default: 'created'
     required: false
   delete-branch:

--- a/action.yml
+++ b/action.yml
@@ -136,6 +136,10 @@ inputs:
     description: 'The order to get issues or pull requests. Defaults to false, which is descending.'
     default: 'false'
     required: false
+  sort-issues-by:
+    description: 'What to sort results by'
+    default: 'created'
+    required: false
   delete-branch:
     description: 'Delete the git branch after closing a stale pull request.'
     default: 'false'

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,5 +1,3 @@
-const { sort } = require('semver');
-
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
@@ -686,12 +684,11 @@ class IssuesProcessor {
                     state: 'open',
                     per_page: 100,
                     direction: this.options.ascending ? 'asc' : 'desc',
-                    sort:
-                    this.options.sortIssuesBy === 'updated'
-                      ? 'updated'
-                      : this.options.sortIssuesBy === 'comments'
-                      ? 'comments'
-                      : 'created',
+                    sort: this.options.sortIssuesBy === 'updated'
+                        ? 'updated'
+                        : this.options.sortIssuesBy === 'comments'
+                            ? 'comments'
+                            : 'created',
                     page
                 });
                 (_a = this.statistics) === null || _a === void 0 ? void 0 : _a.incrementFetchedItemsCount(issueResult.data.length);
@@ -2207,7 +2204,7 @@ var Option;
     Option["RemovePrStaleWhenUpdated"] = "remove-pr-stale-when-updated";
     Option["DebugOnly"] = "debug-only";
     Option["Ascending"] = "ascending";
-    Option["SortIssuesBy"] = 'sort-issues-by';
+    Option["SortIssuesBy"] = "sort-issues-by";
     Option["DeleteBranch"] = "delete-branch";
     Option["StartDate"] = "start-date";
     Option["ExemptMilestones"] = "exempt-milestones";

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,3 +1,5 @@
+const { sort } = require('semver');
+
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
@@ -684,6 +686,12 @@ class IssuesProcessor {
                     state: 'open',
                     per_page: 100,
                     direction: this.options.ascending ? 'asc' : 'desc',
+                    sort:
+                    this.options.sortIssuesBy === 'updated'
+                      ? 'updated'
+                      : this.options.sortIssuesBy === 'comments'
+                      ? 'comments'
+                      : 'created',
                     page
                 });
                 (_a = this.statistics) === null || _a === void 0 ? void 0 : _a.incrementFetchedItemsCount(issueResult.data.length);
@@ -2199,6 +2207,7 @@ var Option;
     Option["RemovePrStaleWhenUpdated"] = "remove-pr-stale-when-updated";
     Option["DebugOnly"] = "debug-only";
     Option["Ascending"] = "ascending";
+    Option["SortIssuesBy"] = 'sort-issues-by';
     Option["DeleteBranch"] = "delete-branch";
     Option["StartDate"] = "start-date";
     Option["ExemptMilestones"] = "exempt-milestones";
@@ -2542,6 +2551,7 @@ function _getAndValidateArgs() {
         removePrStaleWhenUpdated: _toOptionalBoolean('remove-pr-stale-when-updated'),
         debugOnly: core.getInput('debug-only') === 'true',
         ascending: core.getInput('ascending') === 'true',
+        sortIssuesBy: core.getInput('sort-issues-by'),
         deleteBranch: core.getInput('delete-branch') === 'true',
         startDate: core.getInput('start-date') !== ''
             ? core.getInput('start-date')

--- a/dist/index.js
+++ b/dist/index.js
@@ -382,6 +382,7 @@ const statistics_1 = __nccwpck_require__(3334);
 const logger_service_1 = __nccwpck_require__(1973);
 const plugin_retry_1 = __nccwpck_require__(6298);
 const rate_limit_1 = __nccwpck_require__(7069);
+const get_sort_field_1 = __nccwpck_require__(9551);
 /***
  * Handle processing of issues for staleness/closure.
  */
@@ -684,11 +685,7 @@ class IssuesProcessor {
                     state: 'open',
                     per_page: 100,
                     direction: this.options.ascending ? 'asc' : 'desc',
-                    sort: this.options.sortIssuesBy === 'updated'
-                        ? 'updated'
-                        : this.options.sortIssuesBy === 'comments'
-                            ? 'comments'
-                            : 'created',
+                    sort: (0, get_sort_field_1.getSortField)(this.options.sortIssuesBy),
                     page
                 });
                 (_a = this.statistics) === null || _a === void 0 ? void 0 : _a.incrementFetchedItemsCount(issueResult.data.length);
@@ -2341,6 +2338,25 @@ exports.isValidDate = isValidDate;
 
 /***/ }),
 
+/***/ 9551:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.getSortField = void 0;
+function getSortField(sortOption) {
+    return sortOption === 'updated'
+        ? 'updated'
+        : sortOption === 'comments'
+            ? 'comments'
+            : 'created';
+}
+exports.getSortField = getSortField;
+
+
+/***/ }),
+
 /***/ 8236:
 /***/ ((__unused_webpack_module, exports) => {
 
@@ -2548,7 +2564,7 @@ function _getAndValidateArgs() {
         removePrStaleWhenUpdated: _toOptionalBoolean('remove-pr-stale-when-updated'),
         debugOnly: core.getInput('debug-only') === 'true',
         ascending: core.getInput('ascending') === 'true',
-        sortIssuesBy: core.getInput('sort-issues-by'),
+        sortIssuesBy: _processParamtoString(core.getInput('sort-issues-by')),
         deleteBranch: core.getInput('delete-branch') === 'true',
         startDate: core.getInput('start-date') !== ''
             ? core.getInput('start-date')
@@ -2634,6 +2650,13 @@ function _toOptionalBoolean(argumentName) {
         return false;
     }
     return undefined;
+}
+function _processParamtoString(sortByValueInput) {
+    return sortByValueInput === 'updated'
+        ? 'updated'
+        : sortByValueInput === 'comments'
+            ? 'comments'
+            : 'created';
 }
 void _run();
 

--- a/src/classes/issue.spec.ts
+++ b/src/classes/issue.spec.ts
@@ -13,6 +13,7 @@ describe('Issue', (): void => {
   beforeEach((): void => {
     optionsInterface = {
       ascending: false,
+      sortIssuesBy:'created',
       closeIssueLabel: '',
       closeIssueMessage: '',
       closePrLabel: '',

--- a/src/classes/issue.spec.ts
+++ b/src/classes/issue.spec.ts
@@ -13,7 +13,7 @@ describe('Issue', (): void => {
   beforeEach((): void => {
     optionsInterface = {
       ascending: false,
-      sortIssuesBy:'created',
+      sortIssuesBy: 'created',
       closeIssueLabel: '',
       closeIssueMessage: '',
       closePrLabel: '',

--- a/src/classes/issues-processor.ts
+++ b/src/classes/issues-processor.ts
@@ -564,6 +564,7 @@ export class IssuesProcessor {
   }
 
   _getSortField(sortOption: sortOption): sortOption {
+    console.log("sort ",sortOption)
     return sortOption === 'updated'
       ? 'updated'
       : sortOption === 'comments'

--- a/src/classes/issues-processor.ts
+++ b/src/classes/issues-processor.ts
@@ -29,12 +29,11 @@ import {retry} from '@octokit/plugin-retry';
 import {IState} from '../interfaces/state/state';
 import {IRateLimit} from '../interfaces/rate-limit';
 import {RateLimit} from './rate-limit';
+import {getSortField} from '../functions/get-sort-field';
 
 /***
  * Handle processing of issues for staleness/closure.
  */
-
-type sortOption = 'created' | 'updated' | 'comments';
 
 export class IssuesProcessor {
   private static _updatedSince(timestamp: string, num_days: number): boolean {
@@ -563,15 +562,6 @@ export class IssuesProcessor {
     }
   }
 
-  _getSortField(sortOption: sortOption): sortOption {
-    console.log("sort ",sortOption)
-    return sortOption === 'updated'
-      ? 'updated'
-      : sortOption === 'comments'
-      ? 'comments'
-      : 'created';
-  }
-
   // grab issues from github in batches of 100
   async getIssues(page: number): Promise<Issue[]> {
     try {
@@ -582,7 +572,7 @@ export class IssuesProcessor {
         state: 'open',
         per_page: 100,
         direction: this.options.ascending ? 'asc' : 'desc',
-        sort: this._getSortField(this.options.sortIssuesBy),
+        sort: getSortField(this.options.sortIssuesBy),
         page
       });
       this.statistics?.incrementFetchedItemsCount(issueResult.data.length);

--- a/src/classes/issues-processor.ts
+++ b/src/classes/issues-processor.ts
@@ -34,6 +34,8 @@ import {RateLimit} from './rate-limit';
  * Handle processing of issues for staleness/closure.
  */
 
+type sortOption = 'created' | 'updated' | 'comments';
+
 export class IssuesProcessor {
   private static _updatedSince(timestamp: string, num_days: number): boolean {
     const daysInMillis = 1000 * 60 * 60 * 24 * num_days;
@@ -559,6 +561,14 @@ export class IssuesProcessor {
       this._logger.error(`List issue comments error: ${error.message}`);
       return Promise.resolve([]);
     }
+  }
+
+  _getSortField(sortOption: sortOption): sortOption {
+    return sortOption === 'updated'
+      ? 'updated'
+      : sortOption === 'comments'
+      ? 'comments'
+      : 'created';
   }
 
   // grab issues from github in batches of 100

--- a/src/classes/issues-processor.ts
+++ b/src/classes/issues-processor.ts
@@ -571,6 +571,12 @@ export class IssuesProcessor {
         state: 'open',
         per_page: 100,
         direction: this.options.ascending ? 'asc' : 'desc',
+        sort:
+          this.options.sortIssuesBy === 'updated'
+            ? 'updated'
+            : this.options.sortIssuesBy === 'comments'
+            ? 'comments'
+            : 'created',
         page
       });
       this.statistics?.incrementFetchedItemsCount(issueResult.data.length);

--- a/src/classes/issues-processor.ts
+++ b/src/classes/issues-processor.ts
@@ -571,12 +571,7 @@ export class IssuesProcessor {
         state: 'open',
         per_page: 100,
         direction: this.options.ascending ? 'asc' : 'desc',
-        sort:
-          this.options.sortIssuesBy === 'updated'
-            ? 'updated'
-            : this.options.sortIssuesBy === 'comments'
-            ? 'comments'
-            : 'created',
+        sort: this._getSortField(this.options.sortIssuesBy),
         page
       });
       this.statistics?.incrementFetchedItemsCount(issueResult.data.length);

--- a/src/enums/option.ts
+++ b/src/enums/option.ts
@@ -26,6 +26,7 @@ export enum Option {
   RemovePrStaleWhenUpdated = 'remove-pr-stale-when-updated',
   DebugOnly = 'debug-only',
   Ascending = 'ascending',
+  SortIssuesBy = 'sort-issues-by',
   DeleteBranch = 'delete-branch',
   StartDate = 'start-date',
   ExemptMilestones = 'exempt-milestones',

--- a/src/functions/get-sort-field.ts
+++ b/src/functions/get-sort-field.ts
@@ -1,8 +1,8 @@
 type sortOptions = 'created' | 'updated' | 'comments';
 export function getSortField(sortOption: sortOptions): sortOptions {
-    return sortOption === 'updated'
-      ? 'updated'
-      : sortOption === 'comments'
-      ? 'comments'
-      : 'created';
-  }
+  return sortOption === 'updated'
+    ? 'updated'
+    : sortOption === 'comments'
+    ? 'comments'
+    : 'created';
+}

--- a/src/functions/get-sort-field.ts
+++ b/src/functions/get-sort-field.ts
@@ -1,0 +1,8 @@
+type sortOptions = 'created' | 'updated' | 'comments';
+export function getSortField(sortOption: sortOptions): sortOptions {
+    return sortOption === 'updated'
+      ? 'updated'
+      : sortOption === 'comments'
+      ? 'comments'
+      : 'created';
+  }

--- a/src/interfaces/issues-processor-options.ts
+++ b/src/interfaces/issues-processor-options.ts
@@ -30,6 +30,7 @@ export interface IIssuesProcessorOptions {
   removePrStaleWhenUpdated: boolean | undefined;
   debugOnly: boolean;
   ascending: boolean;
+  sortIssuesBy: string;
   deleteBranch: boolean;
   startDate: IsoOrRfcDateString | undefined; // Should be ISO 8601 or RFC 2822
   exemptMilestones: string;

--- a/src/interfaces/issues-processor-options.ts
+++ b/src/interfaces/issues-processor-options.ts
@@ -30,7 +30,7 @@ export interface IIssuesProcessorOptions {
   removePrStaleWhenUpdated: boolean | undefined;
   debugOnly: boolean;
   ascending: boolean;
-  sortIssuesBy: string;
+  sortIssuesBy: 'created' | 'updated' | 'comments';
   deleteBranch: boolean;
   startDate: IsoOrRfcDateString | undefined; // Should be ISO 8601 or RFC 2822
   exemptMilestones: string;

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import {IIssuesProcessorOptions} from './interfaces/issues-processor-options';
 import {Issue} from './classes/issue';
 import {getStateInstance} from './services/state.service';
 
+
 async function _run(): Promise<void> {
   try {
     const args = _getAndValidateArgs();
@@ -97,7 +98,7 @@ function _getAndValidateArgs(): IIssuesProcessorOptions {
     ),
     debugOnly: core.getInput('debug-only') === 'true',
     ascending: core.getInput('ascending') === 'true',
-    sortIssuesBy: core.getInput('sort-issues-by'),
+    sortIssuesBy: _processParamtoString(core.getInput('sort-issues-by')),
     deleteBranch: core.getInput('delete-branch') === 'true',
     startDate:
       core.getInput('start-date') !== ''
@@ -197,6 +198,14 @@ function _toOptionalBoolean(
   }
 
   return undefined;
+}
+
+function _processParamtoString(sortByValueInput: string): 'created' | 'updated' | 'comments' {
+  return sortByValueInput === 'updated'
+    ? 'updated'
+    : sortByValueInput === 'comments'
+    ? 'comments'
+    : 'created';
 }
 
 void _run();

--- a/src/main.ts
+++ b/src/main.ts
@@ -97,6 +97,7 @@ function _getAndValidateArgs(): IIssuesProcessorOptions {
     ),
     debugOnly: core.getInput('debug-only') === 'true',
     ascending: core.getInput('ascending') === 'true',
+    sortIssuesBy: core.getInput('sort-issues-by'),
     deleteBranch: core.getInput('delete-branch') === 'true',
     startDate:
       core.getInput('start-date') !== ''

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,6 @@ import {IIssuesProcessorOptions} from './interfaces/issues-processor-options';
 import {Issue} from './classes/issue';
 import {getStateInstance} from './services/state.service';
 
-
 async function _run(): Promise<void> {
   try {
     const args = _getAndValidateArgs();
@@ -200,7 +199,9 @@ function _toOptionalBoolean(
   return undefined;
 }
 
-function _processParamtoString(sortByValueInput: string): 'created' | 'updated' | 'comments' {
+function _processParamtoString(
+  sortByValueInput: string
+): 'created' | 'updated' | 'comments' {
   return sortByValueInput === 'updated'
     ? 'updated'
     : sortByValueInput === 'comments'


### PR DESCRIPTION
Description:
Introducing a new option sort-issues-by to sort the issues by the specified field. It accepts 'created', 'updated', 'comments' as values and default value is set to 'created', defines the sorting order of the issues in a repository.

Related issue:
Related to https://github.com/actions/stale/issues/1231

Check list:

[✓ ] Mark if documentation changes are required.